### PR TITLE
Misc fixes to building + plugin loading.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: skyline
 
 skyline:
 	$(MAKE) all -f MakefileNSO CROSSVER=$(CROSSVER)
-	$(MAKE) skyline_patch_$(CROSSVER)/*.ips
+#	$(MAKE) skyline_patch_$(CROSSVER)/*.ips
 
 skyline_patch_$(CROSSVER)/*.ips: patches/*.slpatch patches/configs/$(CROSSVER).config patches/maps/$(CROSSVER)/*.map \
 								build$(CROSSVER)/$(shell basename $(CURDIR))$(CROSSVER).map scripts/genPatch.py

--- a/include/nn/ro.h
+++ b/include/nn/ro.h
@@ -97,9 +97,28 @@ namespace nn
 
         Result Initialize();
 
-        void LookupSymbol(ulong *, char const*);
-
-        Result LoadModule(Module*, void const*, void*, ulong, int);
+        /**
+        * Searches for the symbol with specified name from among all loaded modules.
+        *
+        * @param pOutAddress The address that stores the address of the symbol.
+        * @param name The symbol name to search for.
+        * @return Returns a nn::Result that represents the process result.
+        */
+        Result LookupSymbol(uintptr_t *pOutAddress, const char *name);
+        /**
+        * Searches for the symbol with the specified name inside the specified module.
+        *
+        * @param pOutAddress The address that stores the address of the symbol.
+        * @param pModule The address that stores the Module object.
+        * @param name The symbol name to search for.
+        * @return Returns a nn::Result that represents the process result.
+        */
+        Result LookupModuleSymbol(uintptr_t *pOutAddress, const Module *pModule, const char *name);
+        Result LoadModule(Module *pOutModule, const void *pImage, void *buffer, size_t bufferSize,int flag);
+        /**
+        * Loads the Module object.
+        */
+        // Result LoadModule(Module *pOutModule, const void *pImage, void *buffer, size_t bufferSize,int flag, bool isNotReferenced);
         Result UnloadModule(Module*);
         Result GetBufferSize(size_t*, const void*);
 

--- a/include/nn/ro.h
+++ b/include/nn/ro.h
@@ -97,27 +97,11 @@ namespace nn
 
         Result Initialize();
 
-        /**
-        * Searches for the symbol with specified name from among all loaded modules.
-        *
-        * @param pOutAddress The address that stores the address of the symbol.
-        * @param name The symbol name to search for.
-        * @return Returns a nn::Result that represents the process result.
-        */
+
         Result LookupSymbol(uintptr_t *pOutAddress, const char *name);
-        /**
-        * Searches for the symbol with the specified name inside the specified module.
-        *
-        * @param pOutAddress The address that stores the address of the symbol.
-        * @param pModule The address that stores the Module object.
-        * @param name The symbol name to search for.
-        * @return Returns a nn::Result that represents the process result.
-        */
+
         Result LookupModuleSymbol(uintptr_t *pOutAddress, const Module *pModule, const char *name);
         Result LoadModule(Module *pOutModule, const void *pImage, void *buffer, size_t bufferSize,int flag);
-        /**
-        * Loads the Module object.
-        */
         // Result LoadModule(Module *pOutModule, const void *pImage, void *buffer, size_t bufferSize,int flag, bool isNotReferenced);
         Result UnloadModule(Module*);
         Result GetBufferSize(size_t*, const void*);

--- a/include/skyline/plugin/PluginManager.hpp
+++ b/include/skyline/plugin/PluginManager.hpp
@@ -23,6 +23,7 @@ namespace Plugin {
         void*  Data;
         size_t Size;
         Utils::Sha256Hash Hash;
+        nn::ro::Module Module;
     };
 
     class Manager {

--- a/include/skyline/utils/cpputils.hpp
+++ b/include/skyline/utils/cpputils.hpp
@@ -20,7 +20,7 @@ namespace skyline {
         static Result writeFile(std::string const&, s64, void*, size_t);
         
         struct Sha256Hash {
-            u8 hash[0x10];
+            u8 hash[0x20];
 
             bool operator==(const Sha256Hash &o) const {
                 return std::memcmp(this, &o, sizeof(*this)) == 0;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -112,7 +112,7 @@ void runtimePatchMain(void*){
         reinterpret_cast<void*>(lookupCharacterFileHook), 
         (void**) &lookupCharacterFile);
        
-    hashes = new skyline::arc::Hashes();
+    //hashes = new skyline::arc::Hashes();
 
     nn::ro::Initialize();
     A64HookFunction(

--- a/source/skyline/plugin/PluginManager.cpp
+++ b/source/skyline/plugin/PluginManager.cpp
@@ -23,7 +23,8 @@ namespace Plugin {
             nn::fs::GetFileSize(&fileSize, handle);
             nn::fs::CloseFile(handle);
 
-            plugin.Data = memalign(0x1000, fileSize);
+            plugin.Size = fileSize;
+            plugin.Data = memalign(0x1000, plugin.Size);
             skyline::Utils::readFile(path, 0, plugin.Data, plugin.Size);
             skyline::TcpLogger::LogFormat("Read %s", path.c_str());
         }
@@ -42,7 +43,7 @@ namespace Plugin {
 
         char* nrrBin = (char*) memalign(0x1000, nrrSize);
 
-        skyline::TcpLogger::LogFormat("Calculating hashes...");
+        skyline::TcpLogger::Log("Calculating hashes...");
         std::vector<Utils::Sha256Hash> sortedHashes;
         for(auto& kv : plugins){
             PluginInfo& plugin = kv.second;
@@ -58,13 +59,13 @@ namespace Plugin {
 
         memcpy(nrrBin, &nrr, sizeof(nn::ro::NrrHeader));
         
-        skyline::Utils::writeFile("sd:/test.nrr", 0, (void*) nrrBin, nrrSize);
+        //skyline::Utils::writeFile("sd:/test.nrr", 0, (void*) nrrBin, nrrSize);
 
         nn::ro::RegistrationInfo reg;
         Result r = nn::ro::RegisterModuleInfo(&reg, nrrBin);
-        skyline::TcpLogger::LogFormat("Registered the NRR.", r);
+        skyline::TcpLogger::Log("Registered the NRR.");
 
-        skyline::TcpLogger::LogFormat("Loading plugins...");
+        skyline::TcpLogger::Log("Loading plugins...");
         for(auto &kv : plugins){
             PluginInfo& plugin = kv.second;
 
@@ -73,9 +74,8 @@ namespace Plugin {
 
             void* buffer = memalign(0x1000, bufferSize);
 
-            nn::ro::Module module;
-            r = nn::ro::LoadModule(&module, plugin.Data, buffer, bufferSize, nn::ro::BindFlag_Now);
-            skyline::TcpLogger::LogFormat("Loaded %s", kv.first.c_str(), r);
+            r = nn::ro::LoadModule(&plugin.Module, plugin.Data, buffer, bufferSize, nn::ro::BindFlag_Now);
+            skyline::TcpLogger::LogFormat("Loaded %s", kv.first.c_str());
         }
     }
 


### PR DESCRIPTION
 - Use proper size for sha256 in cpputils.
 - Comment out arc hash loading so we don't abort if hashes.txt is missing.
 - Put plugin Module in PluginInfo class.
 - Fix for NRO loading always reading size 0.
 - Don't write generated .nrr to SD.
 - Comment out IPS patch generation for now to prevent build failures from missing Keystone.