### PR TITLE
Fix issues with page-alignment of RW/RX page sizes

### DIFF
--- a/source/skyline/inlinehook/controlledpages.cpp
+++ b/source/skyline/inlinehook/controlledpages.cpp
@@ -157,7 +157,7 @@ namespace skyline::inlinehook {
         if(!isClaimed) {
             // get actual pages
             u64 alignedSrc = ALIGN_DOWN((u64)rx, PAGE_SIZE);
-            size_t alignedSize = ALIGN_UP(size, PAGE_SIZE);
+            size_t alignedSize = ALIGN_UP((u64)rx + size, PAGE_SIZE) - alignedSrc;
             
             // reserve space for rw pages
             u64 dst;
@@ -182,7 +182,7 @@ namespace skyline::inlinehook {
             // get actual pages
             u64 alignedSrc = ALIGN_DOWN((u64)rx, PAGE_SIZE);
             void* alignedDst = (void*) ALIGN_DOWN((u64)rw, PAGE_SIZE);
-            size_t alignedSize = ALIGN_UP(size, PAGE_SIZE);
+            size_t alignedSize = ALIGN_UP((u64)rx + size, PAGE_SIZE) - alignedSrc;
 
             // invalidate caches
             armDCacheFlush((void*)alignedDst, size);


### PR DESCRIPTION
Requires testing before merge.

Things to test:
1. Ensure this isn't a reversion by testing that A64HookFunction works
2. Ensure that this actually fixes modifying .text/.rodata along page boundaries resulting in a lower offset-in-page of the end of the buffer than the start of the buffer.

For example:

```
rx = 0xFFC;
size = 0x8;
```

In this instance, the 4 bytes on the second page would not be properly included in the ControlledPages and will crash if you attempt to write to it due to the second page not being mapped.