### PR TITLE
Rework Plugin Loading

### DIFF
--- a/include/skyline/plugin/PluginManager.hpp
+++ b/include/skyline/plugin/PluginManager.hpp
@@ -9,6 +9,8 @@
 
 namespace skyline::plugin {
 
+    static constexpr auto PLUGIN_PATH = "skyline/plugins";
+
     struct PluginInfo {
         std::string Path;
         std::unique_ptr<u8> Data;
@@ -20,10 +22,11 @@ namespace skyline::plugin {
     };
 
     class Manager {
-        private:
+       private:
         std::list<PluginInfo> m_pluginInfos;
         std::unique_ptr<u8> m_nrrBuffer;
         size_t m_nrrSize;
+        nn::ro::RegistrationInfo m_registrationInfo;
 
         static inline auto& GetInstance() {
             static Manager s_instance;
@@ -32,8 +35,8 @@ namespace skyline::plugin {
 
         void LoadPluginsImpl();
 
-        public:
+       public:
         static inline void LoadPlugins() { GetInstance().LoadPluginsImpl(); }
     };
 
-};
+};  // namespace skyline::plugin

--- a/include/skyline/plugin/PluginManager.hpp
+++ b/include/skyline/plugin/PluginManager.hpp
@@ -7,7 +7,8 @@
 #include "nn/ro.h"
 #include "skyline/utils/cpputils.hpp"
 
-namespace skyline::plugin {
+namespace skyline {
+namespace plugin {
 
     static constexpr auto PLUGIN_PATH = "skyline/plugins";
 
@@ -39,4 +40,5 @@ namespace skyline::plugin {
         static inline void LoadPlugins() { GetInstance().LoadPluginsImpl(); }
     };
 
-};  // namespace skyline::plugin
+};  // namespace plugin
+};  // namespace skyline

--- a/include/skyline/plugin/PluginManager.hpp
+++ b/include/skyline/plugin/PluginManager.hpp
@@ -11,15 +11,19 @@ namespace skyline::plugin {
 
     struct PluginInfo {
         std::string Path;
-        void* Data;
+        std::unique_ptr<u8> Data;
         size_t Size;
         utils::Sha256Hash Hash;
         nn::ro::Module Module;
+        std::unique_ptr<u8> BssData;
+        size_t BssSize;
     };
 
     class Manager {
         private:
         std::list<PluginInfo> m_pluginInfos;
+        std::unique_ptr<u8> m_nrrBuffer;
+        size_t m_nrrSize;
 
         static inline auto& GetInstance() {
             static Manager s_instance;

--- a/include/skyline/plugin/PluginManager.hpp
+++ b/include/skyline/plugin/PluginManager.hpp
@@ -1,31 +1,35 @@
 #pragma once
 
-#include <algorithm>
+#include <list>
 #include <memory>
 #include <string>
-#include <unordered_map>
 
-#include "alloc.h"
-#include "mem.h"
-#include "nn/crypto.h"
 #include "nn/ro.h"
-#include "operator.h"
-#include "skyline/logger/TcpLogger.hpp"
 #include "skyline/utils/cpputils.hpp"
-#include "types.h"
 
 namespace skyline::plugin {
 
-class PluginInfo {
-   public:
-    void* Data;
-    size_t Size;
-    utils::Sha256Hash Hash;
-    nn::ro::Module Module;
-};
+    struct PluginInfo {
+        std::string Path;
+        void* Data;
+        size_t Size;
+        utils::Sha256Hash Hash;
+        nn::ro::Module Module;
+    };
 
-class Manager {
-   public:
-    static void Init();
+    class Manager {
+        private:
+        std::list<PluginInfo> m_pluginInfos;
+
+        static inline auto& GetInstance() {
+            static Manager s_instance;
+            return s_instance;
+        }
+
+        void LoadPluginsImpl();
+
+        public:
+        static inline void LoadPlugins() { GetInstance().LoadPluginsImpl(); }
+    };
+
 };
-};  // namespace skyline::plugin

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -78,8 +78,8 @@ void skyline_main() {
         Result rc = nn::fs::MountSdCardForDebug("sd");
         skyline::logger::s_Instance->LogFormat("[skyline_main] Mounted SD (0x%x)", rc);
 
-        // init plugins
-        skyline::plugin::Manager::Init();
+        // load plugins
+        skyline::plugin::Manager::LoadPlugins();
     }};
 
     taskQueue->push(new std::unique_ptr<skyline::utils::Task>(after_romfs_task));

--- a/source/skyline/plugin/PluginManager.cpp
+++ b/source/skyline/plugin/PluginManager.cpp
@@ -52,7 +52,7 @@ namespace plugin {
             plugin.Size = fileSize;
             plugin.Data = memalign(0x1000, plugin.Size);
 
-            rc = R_SUCCEEDED(skyline::utils::readFile(path, 0, plugin.Data, plugin.Size);
+            rc = skyline::utils::readFile(path, 0, plugin.Data, plugin.Size);
             if(R_SUCCEEDED(rc))
                 skyline::logger::s_Instance->LogFormat("[PluginManager] Read %s", path.c_str());
             else {
@@ -77,10 +77,10 @@ namespace plugin {
         nn::ro::NrrHeader nrr = {
             .magic = 0x3052524E, // NRR0
             .program_id = {program_id},
+            .size = nrrSize,
             .type = 0, // ForSelf
             .hashes_offset = sizeof(nn::ro::NrrHeader),
             .num_hashes = plugins.size(),
-            .size = nrrSize,
         };
         
         char* nrrBin = (char*) memalign(0x1000, nrrSize); // must be page aligned 
@@ -125,7 +125,7 @@ namespace plugin {
 
             // attempt to get the required size for the bss 
             size_t bssSize;
-            if(R_FAILED(nn::ro::GetBufferSize(&bssSize, plugin.Data)) {
+            if(R_FAILED(nn::ro::GetBufferSize(&bssSize, plugin.Data))) {
                 // ro rejected file, bail (the original input is not validated to be an actual NRO, so this isn't unusual)
                 
                 // we don't need the file data any more

--- a/source/skyline/plugin/PluginManager.cpp
+++ b/source/skyline/plugin/PluginManager.cpp
@@ -5,7 +5,8 @@
 #include "nn/crypto.h"
 #include "skyline/logger/TcpLogger.hpp"
 
-namespace skyline::plugin {
+namespace skyline {
+namespace plugin {
 
     void Manager::LoadPluginsImpl() {
         Result rc;
@@ -202,4 +203,5 @@ namespace skyline::plugin {
         }
     }
 
-};  // namespace skyline::plugin
+};  // namespace plugin
+};  // namespace skyline

--- a/source/skyline/plugin/PluginManager.cpp
+++ b/source/skyline/plugin/PluginManager.cpp
@@ -84,6 +84,7 @@ namespace plugin {
         };
         
         char* nrrBin = (char*) memalign(0x1000, nrrSize); // must be page aligned 
+        memset(nrrBin, 0, nrrSize);
 
         skyline::logger::s_Instance->LogFormat("[PluginManager] Calculating hashes...");
         std::vector<utils::Sha256Hash> sortedHashes;

--- a/source/skyline/plugin/PluginManager.cpp
+++ b/source/skyline/plugin/PluginManager.cpp
@@ -139,7 +139,7 @@ namespace plugin {
 
             void* bss = memalign(0x1000, bssSize); // must be page aligned 
 
-            rc = nn::ro::LoadModule(&plugin.Module, plugin.Data, bss, bufferSize, nn::ro::BindFlag_Now);// bind immediately, so all symbols are immediately available
+            rc = nn::ro::LoadModule(&plugin.Module, plugin.Data, bss, bssSize, nn::ro::BindFlag_Now);// bind immediately, so all symbols are immediately available
  
             if(R_SUCCEEDED(rc)) {
                 skyline::logger::s_Instance->LogFormat("[PluginManager] Loaded %s", kv.first.c_str(), &plugin.Module.Name);

--- a/source/skyline/plugin/PluginManager.cpp
+++ b/source/skyline/plugin/PluginManager.cpp
@@ -2,38 +2,38 @@
 
 #include <set>
 
-namespace skyline {
-namespace plugin {
+#include "nn/crypto.h"
+#include "skyline/logger/TcpLogger.hpp"
 
-    void Manager::Init() {
+namespace skyline::plugin {
+
+    void Manager::LoadPluginsImpl() {
         Result rc;
 
         skyline::logger::s_Instance->LogFormat("[PluginManager] Initializing plugins...");
         
-        std::unordered_map<std::string, PluginInfo> plugins;
-        
         // walk through romfs:/skyline/plugins recursively to find any files and push them into map
-        skyline::utils::walkDirectory(utils::g_RomMountStr + "skyline/plugins", 
-        [&plugins](nn::fs::DirectoryEntry const& entry, std::shared_ptr<std::string> path) {
-            if(entry.type == nn::fs::DirectoryEntryType_File) // ignore directories
-                plugins[*path] = PluginInfo();
-        });
+        skyline::utils::walkDirectory(utils::g_RomMountStr + "skyline/plugins",
+                                      [this](nn::fs::DirectoryEntry const& entry, std::shared_ptr<std::string> path) {
+                                          if (entry.type == nn::fs::DirectoryEntryType_File)  // ignore directories
+                                              m_pluginInfos.push_back(PluginInfo{.Path = *path});
+                                      });
         
         skyline::logger::s_Instance->LogFormat("[PluginManager] Opening plugins...");
-        for (auto& kv : plugins) {
-            std::string path = kv.first;
-            PluginInfo& plugin = kv.second;
+        auto pluginInfoIter = m_pluginInfos.begin();
+        while (pluginInfoIter != m_pluginInfos.end()) {
+            auto& plugin = *pluginInfoIter;
 
             // open file
             nn::fs::FileHandle handle;
-            rc = nn::fs::OpenFile(&handle, path.c_str(), nn::fs::OpenMode_Read);
+            rc = nn::fs::OpenFile(&handle, plugin.Path.c_str(), nn::fs::OpenMode_Read);
             
             // file couldn't be opened, bail
-            if(R_FAILED(rc)){
-                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to open '%s' (0x%x). Skipping.", path.c_str(), rc);
-                
+            if (R_FAILED(rc)) {
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to open '%s' (0x%x). Skipping.",
+                                                       plugin.Path.c_str(), rc);
                 // stop tracking
-                plugins.erase(kv.first);
+                pluginInfoIter = m_pluginInfos.erase(pluginInfoIter);
                 continue;
             }
 
@@ -42,50 +42,62 @@ namespace plugin {
             nn::fs::CloseFile(handle); // file should be closed regardless of anything failing
             
             // getting file size failed, bail
-            if(R_FAILED(rc)) {
-                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to get '%s' size. (0x%x). Skipping.", path.c_str(), rc);
-                
+            if (R_FAILED(rc)) {
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to get '%s' size. (0x%x). Skipping.",
+                                                       plugin.Path.c_str(), rc);
+
                 // stop tracking
-                plugins.erase(kv.first);
-                
+                pluginInfoIter = m_pluginInfos.erase(pluginInfoIter);
                 continue;
             }
 
             plugin.Size = fileSize;
             plugin.Data = memalign(0x1000, plugin.Size);
 
-            rc = skyline::utils::readFile(path, 0, plugin.Data, plugin.Size);
-            if(R_SUCCEEDED(rc))
-                skyline::logger::s_Instance->LogFormat("[PluginManager] Read %s", path.c_str());
+            rc = skyline::utils::readFile(plugin.Path, 0, plugin.Data, plugin.Size);
+            if (R_SUCCEEDED(rc))
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Read %s", plugin.Path.c_str());
             else {
-                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to read '%s'. (0x%x). Skipping.", path.c_str(), rc);
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to read '%s'. (0x%x). Skipping.",
+                                                       plugin.Path.c_str(), rc);
                 
                 // free space allocated for the file
                 free(plugin.Data);
                 
                 // stop tracking
-                plugins.erase(kv.first);
+                pluginInfoIter = m_pluginInfos.erase(pluginInfoIter);
+                continue;
             }
+            
+            pluginInfoIter++;
         }
 
         skyline::logger::s_Instance->LogFormat("[PluginManager] Calculating hashes...");
 
         // ro requires hashes to be sorted
         std::set<utils::Sha256Hash> sortedHashes;
-        for (auto& kv : plugins) {
-            PluginInfo& plugin = kv.second;
+        pluginInfoIter = m_pluginInfos.begin();
+        while (pluginInfoIter != m_pluginInfos.end()) {
+            auto& plugin = *pluginInfoIter;
             nn::ro::NroHeader* nro = (nn::ro::NroHeader*)plugin.Data;
             nn::crypto::GenerateSha256Hash(&plugin.Hash, sizeof(utils::Sha256Hash), nro, nro->size);
-            if (sortedHashes.find(plugin.Hash) == sortedHashes.end()) {
-                sortedHashes.insert(plugin.Hash);
-            } else {
-                // duplicate, stop tracking
-                plugins.erase(kv.first);
+
+            if (sortedHashes.find(plugin.Hash) != sortedHashes.end()) {
+                skyline::logger::s_Instance->LogFormat("[PluginManager] %s is detected duplicate, ignoring...",
+                                                       plugin.Path.c_str());
+
+                // stop tracking
+                pluginInfoIter = m_pluginInfos.erase(pluginInfoIter);
+                continue;
             }
+
+            sortedHashes.insert(plugin.Hash);
+            pluginInfoIter++;
         }
 
         // (sizeof(nrr header) + sizeof(sha256) * plugin count) aligned by 0x1000, as required by ro
-        size_t nrrSize = ALIGN_UP(sizeof(nn::ro::NrrHeader) + (plugins.size() * sizeof(utils::Sha256Hash)), 0x1000);
+        size_t nrrSize =
+            ALIGN_UP(sizeof(nn::ro::NrrHeader) + (m_pluginInfos.size() * sizeof(utils::Sha256Hash)), 0x1000);
 
         // get our own program ID
         // TODO: dedicated util for this
@@ -98,7 +110,7 @@ namespace plugin {
             .size = nrrSize,
             .type = 0, // ForSelf
             .hashes_offset = sizeof(nn::ro::NrrHeader),
-            .num_hashes = plugins.size(),
+            .num_hashes = m_pluginInfos.size(),
         };
         
         char* nrrBin = (char*) memalign(0x1000, nrrSize); // must be page aligned 
@@ -123,53 +135,66 @@ namespace plugin {
             free(nrrBin);
             
             // free all loaded plugins
-            for(auto& kv : plugins)
-                free(kv.second.Data);
+            // for(auto& kv : plugins)  TODO: refactor to smart pointer, no need to free
+            //     free(kv.second.Data);
             
             skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to register NRR (0x%x).", rc);
             return;
         }
 
         skyline::logger::s_Instance->Log("[PluginManager] Loading plugins...\n");
-        for (auto& kv : plugins) {
-            PluginInfo& plugin = kv.second;
+        pluginInfoIter = m_pluginInfos.begin();
+        while (pluginInfoIter != m_pluginInfos.end()) {
+            auto& plugin = *pluginInfoIter;
 
             // attempt to get the required size for the bss 
             size_t bssSize;
-            if(R_FAILED(nn::ro::GetBufferSize(&bssSize, plugin.Data))) {
-                // ro rejected file, bail (the original input is not validated to be an actual NRO, so this isn't unusual)
+            rc = nn::ro::GetBufferSize(&bssSize, plugin.Data);
+            if (R_FAILED(rc)) {
+                // ro rejected file, bail
+                // (the original input is not validated to be an actual NRO, so this isn't unusual)
+                skyline::logger::s_Instance->LogFormat(
+                    "[PluginManager] nn::ro::GetBufferSize failed on %s (0x%x), not an nro?", plugin.Path.c_str(), rc);
                 
                 // we don't need the file data any more
                 free(plugin.Data);
                 
                 // stop tracking
-                plugins.erase(kv.first);
+                pluginInfoIter = m_pluginInfos.erase(pluginInfoIter);
                 
                 continue;
             }
 
             void* bss = memalign(0x1000, bssSize); // must be page aligned 
 
-            rc = nn::ro::LoadModule(&plugin.Module, plugin.Data, bss, bssSize, nn::ro::BindFlag_Now);// bind immediately, so all symbols are immediately available
+            rc = nn::ro::LoadModule(
+                &plugin.Module, plugin.Data, bss, bssSize,
+                nn::ro::BindFlag_Now);  // bind immediately, so all symbols are immediately available
  
-            if(R_SUCCEEDED(rc)) {
-                skyline::logger::s_Instance->LogFormat("[PluginManager] Loaded %s", kv.first.c_str(), &plugin.Module.Name);
+            if (R_SUCCEEDED(rc)) {
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Loaded %s", plugin.Path.c_str(),
+                                                       &plugin.Module.Name);
             } else {
-               skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to load %s, return code: 0x%x", kv.first.c_str(), rc);
-                
-               // couldn't be loaded, free unused memory
-               free(bss);
-               free(plugin.Data);
-                
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to load %s, return code: 0x%x",
+                                                       plugin.Path.c_str(), rc);
+
+                // couldn't be loaded, free unused memory
+                free(bss);
+                free(plugin.Data);
+
                 // stop tracking
-               plugins.erase(kv.first);
+                pluginInfoIter = m_pluginInfos.erase(pluginInfoIter);
+                continue;
             }
+
+            pluginInfoIter++;
         }
 
-        for (auto& kv : plugins) {
-            PluginInfo& plugin = kv.second;
+        pluginInfoIter = m_pluginInfos.begin();
+        while (pluginInfoIter != m_pluginInfos.end()) {
+            auto& plugin = *pluginInfoIter;
 
-            skyline::logger::s_Instance->LogFormat("[PluginManager] Running `main` for %s", kv.first.c_str(),
+            skyline::logger::s_Instance->LogFormat("[PluginManager] Running `main` for %s", plugin.Path.c_str(),
                                                    &plugin.Module.Name);
 
             // try to find entrypoint
@@ -179,15 +204,17 @@ namespace plugin {
                 &plugin.Module,
                 "main");
             
-            if(pluginEntrypoint != NULL && R_SUCCEEDED(rc)) {
+            if (pluginEntrypoint != NULL && R_SUCCEEDED(rc)) {
                 pluginEntrypoint();
                 skyline::logger::s_Instance->LogFormat("[PluginManager] Finished running `main` for %s, rc: 0x%x",
-                                                       kv.first.c_str(), rc);
+                                                       plugin.Path.c_str(), rc);
             } else {
                 skyline::logger::s_Instance->LogFormat(
-                    "[PluginManager] Failed to lookup symbol for %s, return code: 0x%x", kv.first.c_str(), rc);
+                    "[PluginManager] Failed to lookup symbol for %s, return code: 0x%x", plugin.Path.c_str(), rc);
             }
+            
+            pluginInfoIter++;
         }
     }
-};  // namespace plugin
-};  // namespace skyline
+
+};

--- a/source/skyline/plugin/PluginManager.cpp
+++ b/source/skyline/plugin/PluginManager.cpp
@@ -7,54 +7,83 @@ namespace plugin {
         Result rc;
 
         skyline::logger::s_Instance->LogFormat("[PluginManager] Initializing plugins...");
+        
         std::unordered_map<std::string, PluginInfo> plugins;
-        skyline::utils::walkDirectory(
-            utils::g_RomMountStr + "skyline/plugins",
-            [&plugins](nn::fs::DirectoryEntry const& entry, std::shared_ptr<std::string> path) {
-                if (entry.type == nn::fs::DirectoryEntryType_File) plugins[*path] = PluginInfo();
-            });
-
+        
+        // walk through romfs:/skyline/plugins recursively to find any files and push them into map
+        skyline::utils::walkDirectory(utils::g_RomMountStr + "skyline/plugins", 
+        [&plugins](nn::fs::DirectoryEntry const& entry, std::shared_ptr<std::string> path) {
+            if(entry.type == nn::fs::DirectoryEntryType_File) // ignore directories
+                plugins[*path] = PluginInfo();
+        });
+        
         skyline::logger::s_Instance->LogFormat("[PluginManager] Opening plugins...");
         for (auto& kv : plugins) {
             std::string path = kv.first;
             PluginInfo& plugin = kv.second;
 
-            // grab file size
+            // open file
             nn::fs::FileHandle handle;
             rc = nn::fs::OpenFile(&handle, path.c_str(), nn::fs::OpenMode_Read);
-            if (R_FAILED(rc)) {
-                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to open '%s' (0x%x). Skipping.",
-                                                       path.c_str(), rc);
+            
+            // file couldn't be opened, bail
+            if(R_FAILED(rc)){
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to open '%s' (0x%x). Skipping.", path.c_str(), rc);
+                
+                // stop tracking
+                plugins.erase(kv.first);
                 continue;
             }
 
             s64 fileSize;
-            nn::fs::GetFileSize(&fileSize, handle);
-            nn::fs::CloseFile(handle);
+            rc = nn::fs::GetFileSize(&fileSize, handle);
+            nn::fs::CloseFile(handle); // file should be closed regardless of anything failing
+            
+            // getting file size failed, bail
+            if(R_FAILED(rc)) {
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to get '%s' size. (0x%x). Skipping.", path.c_str(), rc);
+                
+                // stop tracking
+                plugins.erase(kv.first);
+                
+                continue;
+            }
 
             plugin.Size = fileSize;
             plugin.Data = memalign(0x1000, plugin.Size);
 
-            skyline::utils::readFile(path, 0, plugin.Data, plugin.Size);
-            skyline::logger::s_Instance->LogFormat("[PluginManager] Read %s", path.c_str());
+            rc = R_SUCCEEDED(skyline::utils::readFile(path, 0, plugin.Data, plugin.Size);
+            if(R_SUCCEEDED(rc))
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Read %s", path.c_str());
+            else {
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to read '%s'. (0x%x). Skipping.", path.c_str(), rc);
+                
+                // free space allocated for the file
+                free(plugin.Data);
+                
+                // stop tracking
+                plugins.erase(kv.first);
+            }
         }
 
+        // (sizeof(nrr header) + sizeof(sha256) * plugin count) aligned by 0x1000, as required by ro
         size_t nrrSize = ALIGN_UP(sizeof(nn::ro::NrrHeader) + (plugins.size() * sizeof(utils::Sha256Hash)), 0x1000);
 
-        nn::ro::NrrHeader nrr;
-        memset(&nrr, 0, sizeof(nn::ro::NrrHeader));
-
+        // get our own program ID
+        // TODO: dedicated util for this
         u64 program_id;
         svcGetInfo(&program_id, 18, INVALID_HANDLE, 0);
-
-        nrr.magic = 0x3052524E;  // NRR0
-        nrr.program_id = {program_id};
-        nrr.type = 0;  // ForSelf
-        nrr.hashes_offset = sizeof(nn::ro::NrrHeader);
-        nrr.num_hashes = plugins.size();
-        nrr.size = nrrSize;
-
-        char* nrrBin = (char*)memalign(0x1000, nrrSize);
+        
+        nn::ro::NrrHeader nrr = {
+            .magic = 0x3052524E, // NRR0
+            .program_id = {program_id},
+            .type = 0, // ForSelf
+            .hashes_offset = sizeof(nn::ro::NrrHeader),
+            .num_hashes = plugins.size(),
+            .size = nrrSize,
+        };
+        
+        char* nrrBin = (char*) memalign(0x1000, nrrSize); // must be page aligned 
 
         skyline::logger::s_Instance->LogFormat("[PluginManager] Calculating hashes...");
         std::vector<utils::Sha256Hash> sortedHashes;
@@ -64,17 +93,28 @@ namespace plugin {
             nn::crypto::GenerateSha256Hash(&plugin.Hash, sizeof(utils::Sha256Hash), nro, nro->size);
             sortedHashes.push_back(plugin.Hash);
         }
+        // sort hashes, as required by ro
         std::sort(sortedHashes.begin(), sortedHashes.end());
-
+        
+        // copy hashes into nrr
         utils::Sha256Hash* hashes = reinterpret_cast<utils::Sha256Hash*>((u64)(nrrBin) + nrr.hashes_offset);
-        for (auto& hash : sortedHashes) *hashes++ = hash;
+        memcpy(hashes, sortedHashes.data(), sizeof(utils::Sha256Hash) * sortedHashes.size());
 
+        // copy header into nrr
         memcpy(nrrBin, &nrr, sizeof(nn::ro::NrrHeader));
-
+        
+        // try to register plugins
         nn::ro::RegistrationInfo reg;
         rc = nn::ro::RegisterModuleInfo(&reg, nrrBin);
-        if (R_FAILED(rc)) {
+        
+        if(R_FAILED(rc)){
+            // ro rejected, free and bail
             free(nrrBin);
+            
+            // free all loaded plugins
+            for(auto& kv : plugins)
+                free(kv.second.Data);
+            
             skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to register NRR (0x%x).", rc);
             return;
         }
@@ -83,20 +123,35 @@ namespace plugin {
         for (auto& kv : plugins) {
             PluginInfo& plugin = kv.second;
 
-            size_t bufferSize;
-            nn::ro::GetBufferSize(&bufferSize, plugin.Data);
+            // attempt to get the required size for the bss 
+            size_t bssSize;
+            if(R_FAILED(nn::ro::GetBufferSize(&bssSize, plugin.Data)) {
+                // ro rejected file, bail (the original input is not validated to be an actual NRO, so this isn't unusual)
+                
+                // we don't need the file data any more
+                free(plugin.Data);
+                
+                // stop tracking
+                plugins.erase(kv.first);
+                
+                continue;
+            }
 
-            void* buffer = memalign(0x1000, bufferSize);
+            void* bss = memalign(0x1000, bssSize); // must be page aligned 
 
-            rc = nn::ro::LoadModule(&plugin.Module, plugin.Data, buffer, bufferSize, nn::ro::BindFlag_Now);
-            if (!rc) {
-                skyline::logger::s_Instance->LogFormat("[PluginManager] Loaded %s", kv.first.c_str(),
-                                                       &plugin.Module.Name);
+            rc = nn::ro::LoadModule(&plugin.Module, plugin.Data, bss, bufferSize, nn::ro::BindFlag_Now);// bind immediately, so all symbols are immediately available
+ 
+            if(R_SUCCEEDED(rc)) {
+                skyline::logger::s_Instance->LogFormat("[PluginManager] Loaded %s", kv.first.c_str(), &plugin.Module.Name);
             } else {
-                skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to load %s, return code: 0x%x",
-                                                       kv.first.c_str(), rc);
-                // TODO: Don't attempt to run plugin main if we fail to load.
-                // plugins.erase(kv.first);
+               skyline::logger::s_Instance->LogFormat("[PluginManager] Failed to load %s, return code: 0x%x", kv.first.c_str(), rc);
+                
+               // couldn't be loaded, free unused memory
+               free(bss);
+               free(plugin.Data);
+                
+                // stop tracking
+               plugins.erase(kv.first);
             }
         }
 
@@ -106,10 +161,14 @@ namespace plugin {
             skyline::logger::s_Instance->LogFormat("[PluginManager] Running `main` for %s", kv.first.c_str(),
                                                    &plugin.Module.Name);
 
+            // try to find entrypoint
             void (*pluginEntrypoint)() = NULL;
-            rc = 0;
-            rc = nn::ro::LookupModuleSymbol(reinterpret_cast<uintptr_t*>(&pluginEntrypoint), &plugin.Module, "main");
-            if (pluginEntrypoint != NULL && !rc) {
+            rc = nn::ro::LookupModuleSymbol(
+                reinterpret_cast<uintptr_t*>(&pluginEntrypoint),
+                &plugin.Module,
+                "main");
+            
+            if(pluginEntrypoint != NULL && R_SUCCEEDED(rc)) {
                 pluginEntrypoint();
                 skyline::logger::s_Instance->LogFormat("[PluginManager] Finished running `main` for %s, rc: 0x%x",
                                                        kv.first.c_str(), rc);


### PR DESCRIPTION
Reworked details for plugin loader, including:
- Zero-filled NRR buffer
  - garbage in the unused region seemed to cause `ro` to reject verification for some reason. ~~shout out to shaDOW, just make clean bruh~~
- Added a guard against crashes caused by loading duplicate plugins
  - this is to prevent user error, and systems like Mac OS apparently duplicate files in hidden dirs
- Properly handle failed plugins
  - the old erase in range-based for-loops is unintended behavior. In my experience, the iteration either just stops or it could cause crashes by continuing over invalid entries
  - this is changed to iterator based loops, allowing erase with intended behavior
  - also changed the unordered map to std::list, since the path key was never used anyway, and a list is faster and more resource-efficient. If the need for lookups arises in the future it could always be changed again
- Use smart pointer for buffers
  - this is what @shadowninja108 wanted. Less leaky and generally cleaner
  - plugin Manager is changed to a static instance to allow keeping reference of the smart pointers, as well as other data members for better extensibility